### PR TITLE
Remove std::cout call

### DIFF
--- a/src/xeus_sqlite_interpreter.cpp
+++ b/src/xeus_sqlite_interpreter.cpp
@@ -9,7 +9,6 @@
 
 #include <cctype>
 #include <cstdio>
-#include <iostream>
 #include <fstream>
 #include <memory>
 #include <sstream>
@@ -234,8 +233,6 @@ void interpreter::backup(std::string backup_type)
 
 void interpreter::parse_code(const std::vector<std::string>& tokenized_code)
 {
-    std::cout << "You're using magic. " << std::endl;
-
     if (tokenized_code[1] == "LOAD" || tokenized_code[1] == "CREATE")
     {
         m_db_path = tokenized_code[2];


### PR DESCRIPTION
This std::cout call was visible when using the kernel from the console:
![magic](https://user-images.githubusercontent.com/21197331/78993482-0e84e280-7b3e-11ea-800f-b622fbbb2fb5.png)
