### PR TITLE
Improve database creation magic

### DIFF
--- a/examples/Simple operations.ipynb
+++ b/examples/Simple operations.ipynb
@@ -96,7 +96,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%CREATE /Users/mariana/Development/jupyter-ecosystem/xeus-sqlite potato.db "
+    "%CREATE potato.db "
    ]
   },
   {
@@ -134,13 +134,6 @@
    "source": [
     "%DELETE"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This changes the CREATE magic signature.

Instead of taking `path` + `filename` it now takes both in one argument, so this is valid:
Relative path:
```
%CREATE potato.db
```
As well as absolute path (as long as the directories exist):
```
%CREATE /home/JaneDoe/Path/To/Whatever/potato.db
```

It also fixes the database creation (it was always raising "The path doesn't exist.").