### PR TITLE
Only compute a result table if there is one

### DIFF
--- a/src/xeus_sqlite_interpreter.cpp
+++ b/src/xeus_sqlite_interpreter.cpp
@@ -306,10 +306,6 @@ nl::json interpreter::execute_request_impl(int execution_counter,
     /*
         Executes either SQLite code or Jupyter Magic.
     */
-
-    nl::json pub_data;
-    std::string result = "";
-    std::stringstream html_table("");
     std::vector<std::string> tokenized_code = tokenizer(code);
 
     try
@@ -322,41 +318,48 @@ nl::json interpreter::execute_request_impl(int execution_counter,
         //Runs SQLite code
         else
         {
-            SQLite::Statement query(*m_db, code);
+            nl::json pub_data;
+
             tabulate::Table plain_table;
+            std::stringstream html_table("");
 
-            std::vector<std::variant<std::string, tabulate::Table>> column_names;
-            html_table << "<table>\n<tr>\n";
-            for (int column = 0; column < query.getColumnCount(); column++) {
-                std::string name = query.getColumnName(column);
-                column_names.push_back(name);
-                html_table << "<th>" << name << "</th>\n";
-            }
-            plain_table.add_row(column_names);
-            html_table << "</tr>\n";
+            SQLite::Statement query(*m_db, code);
 
-            //Iterates through the columns and prints them
-            while (query.executeStep())
+            if (query.getColumnCount() != 0)
             {
-                html_table << "<tr>\n";
-                std::vector<std::variant<std::string, tabulate::Table>> row;
+                std::vector<std::variant<std::string, tabulate::Table>> column_names;
+                html_table << "<table>\n<tr>\n";
                 for (int column = 0; column < query.getColumnCount(); column++) {
-                    std::string cell = query.getColumn(column);
-                    row.push_back(cell);
-                    html_table << "<td>" << cell << "</td>\n";
+                    std::string name = query.getColumnName(column);
+                    column_names.push_back(name);
+                    html_table << "<th>" << name << "</th>\n";
                 }
+                plain_table.add_row(column_names);
                 html_table << "</tr>\n";
-                plain_table.add_row(row);
-            }
-            result += plain_table.str();
-            html_table << "</table>";
-        }
 
-        if (result.size() > 2)
-        {
-            pub_data["text/plain"] = result;
-            pub_data["text/html"] = html_table.str();
-            publish_execution_result(execution_counter, std::move(pub_data), nl::json::object());
+                //Iterates through the columns and prints them
+                while (query.executeStep())
+                {
+                    html_table << "<tr>\n";
+                    std::vector<std::variant<std::string, tabulate::Table>> row;
+                    for (int column = 0; column < query.getColumnCount(); column++) {
+                        std::string cell = query.getColumn(column);
+                        row.push_back(cell);
+                        html_table << "<td>" << cell << "</td>\n";
+                    }
+                    html_table << "</tr>\n";
+                    plain_table.add_row(row);
+                }
+                html_table << "</table>";
+
+                pub_data["text/plain"] = plain_table.str();
+                pub_data["text/html"] = html_table.str();
+                publish_execution_result(execution_counter, std::move(pub_data), nl::json::object());
+            }
+            else
+            {
+                query.exec();
+            }
         }
 
         nl::json jresult;


### PR DESCRIPTION
This changes a bit the code logic, instead of doing:
- run sqlite command
- compute result table in a string
- check in the string if there is a table, then publish if there is one

I do:
- run sqlite command
- check if there is a table, if there is one compute result table string and publish 