### PR TITLE
Add classes and template + a few other attrs

### DIFF
--- a/include/xeus-sqlite/xvega_bindings.hpp
+++ b/include/xeus-sqlite/xvega_bindings.hpp
@@ -31,59 +31,12 @@ namespace xeus_sqlite
 
         virtual ~xv_sqlite();
 
+        //TODO: either these classes can be moved to the cpp
+        //or the relevant hpp parts on cpp moved here. I'm not sure what's the
+        //best appproach
         static nl::json process_xvega_input(std::vector<std::string>, xv::df_type);
         static std::pair<std::vector<std::string>, std::vector<std::string>>
                split_xv_sqlite_input(std::vector<std::string>);
-
-    private:
-
-        xv_sqlite(xv::Chart&);
-
-        using input_it = std::vector<std::string>::iterator;
-        using free_fun = std::function<void()>;
-        using point_it_fun = std::function<input_it(xv_sqlite&,
-                                                    const input_it&)>;
-        using range_it_fun = std::function<input_it(xv_sqlite&,
-                                                    const input_it&,
-                                                    const input_it&)>;
-        using parse_function_types = xtl::variant<point_it_fun,
-                                                  range_it_fun,
-                                                  free_fun>;
-
-        struct command_info {
-            int number_required_arguments;
-            parse_function_types parse_function;
-        };
-
-        static const std::map<std::string, command_info> xvega_mapping_table;
-        static const std::map<std::string, command_info> mark_mapping_table;
-        static const std::map<std::string, command_info> x_field_mapping_table;
-        static const std::map<std::string, command_info> y_field_mapping_table;
-
-        xv::Chart& chart;
-
-        std::pair<input_it, bool> xvega_execution_step(const input_it&,
-                                      const input_it&,
-                                      const std::map<std::string,
-                                      command_info>);
-
-        input_it parse_width(const input_it&);
-        input_it parse_height(const input_it&);
-
-        input_it parse_x_field(const input_it&, const input_it&);
-        input_it parse_x_field_type(const input_it&, const input_it&);
-        input_it parse_x_field_bin(const input_it&, const input_it&);
-        input_it parse_x_field_aggregate(const input_it&, const input_it&);
-        input_it parse_x_field_title(const input_it&);
-        input_it parse_x_field_grid(const input_it&, const input_it&);
-
-        input_it parse_y_field(const input_it&, const input_it&);
-        input_it parse_y_field_type(const input_it&, const input_it&);
-        input_it parse_y_field_bin(const input_it&, const input_it&);
-        input_it parse_y_field_aggregate(const input_it&, const input_it&);
-
-        input_it parse_mark(const input_it&, const input_it&);
-        input_it parse_mark_color(const input_it&);
     };
 }
 

--- a/src/xeus_sqlite_interpreter.cpp
+++ b/src/xeus_sqlite_interpreter.cpp
@@ -174,10 +174,6 @@ namespace xeus_sqlite
         if (case_insentive_equals(tokenized_input[0], "LOAD"))
         {
             m_db_path = tokenized_input[1];
-
-            // std::ifstream path_is_valid;
-            // path_is_valid.open(m_db_path);
-            // if (!path_is_valid.is_open())
             std::ifstream path_is_valid(m_db_path);
             if (!path_is_valid.is_open())
             {
@@ -185,7 +181,6 @@ namespace xeus_sqlite
             }
             else
             {
-
                 return load_db(tokenized_input);
             }
         }
@@ -423,7 +418,7 @@ namespace xeus_sqlite
     }
 
     nl::json interpreter::complete_request_impl(const std::string& /*code*/,
-                                                    int /*cursor_pos*/)
+                                                int /*cursor_pos*/)
     {
         nl::json jresult;
         jresult["status"] = "ok";
@@ -453,21 +448,19 @@ namespace xeus_sqlite
         result["implementation_version"] = "0.1.0";
 
         /* The jupyter-console banner for xeus-sqlite is the following:
-          __  _____ _   _ ___
-          \ \/ / _ \ | | / __|
-           >  <  __/ |_| \__ \
-          /_/\_\___|\__,_|___/
-          xeus-sqlite: a Jupyter kernel for SQLite
+            _  _ ____ _  _ ____    ____ ____ _    _ ___ ____
+             \/  |___ |  | [__  __ [__  |  | |    |  |  |___
+            _/\_ |___ |__| ___]    ___] |_\| |___ |  |  |___
+          xeus-SQLite: a Jupyter kernel for SQLite
+          SQLite version: x.x.x
         */
 
         std::string banner = ""
-              "  __  _____ _   _ ___\n"
-              "  \\ \\/ / _ \\ | | / __|\n"
-              "   >  <  __/ |_| \\__ \\\n"
-              "  /_/\\_\\___|\\__,_|___/\n"
-              "\n"
-              "  xeus-sqlite: a Jupyter kernel for SQLite\n"
-              "  SQLite ";
+              "_  _ ____ _  _ ____    ____ ____ _    _ ___ ____\n"
+              " \\/  |___ |  | [__  __ [__  |  | |    |  |  |___\n"
+              "_/\\_ |___ |__| ___]    ___] |_\\| |___ |  |  |___\n"
+              "  xeus-SQLite: a Jupyter kernel for SQLite\n"
+              "  SQLite version: ";
         banner.append(SQLite::VERSION);
 
         result["banner"] = banner;

--- a/src/xeus_sqlite_interpreter.cpp
+++ b/src/xeus_sqlite_interpreter.cpp
@@ -129,28 +129,28 @@ namespace xeus_sqlite
         https://www.sqlite.org/fileformat.html#the_database_header*/
         nl::json pub_data;
         pub_data["text/plain"] =
-            "Magic header string: " + std::string(&header.headerStr[0], &header.headerStr[15]) + "\n" +
-            "Page size bytes: " + std::to_string(header.pageSizeBytes) + "\n" +
-            "File format write version: " + std::to_string(header.fileFormatWriteVersion) + "\n" +
-            "File format read version: " + std::to_string(header.fileFormatReadVersion) + "\n" +
-            "Reserved space bytes: " + std::to_string(header.reservedSpaceBytes) + "\n" +
-            "Max embedded payload fraction " + std::to_string(header.maxEmbeddedPayloadFrac) + "\n" +
-            "Min embedded payload fraction: " + std::to_string(header.minEmbeddedPayloadFrac) + "\n" +
-            "Leaf payload fraction: " + std::to_string(header.leafPayloadFrac) + "\n" +
-            "File change counter: " + std::to_string(header.fileChangeCounter) + "\n" +
-            "Database size pages: " + std::to_string(header.databaseSizePages) + "\n" +
-            "First freelist trunk page: " + std::to_string(header.firstFreelistTrunkPage) + "\n" +
-            "Total freelist trunk pages: " + std::to_string(header.totalFreelistPages) + "\n" +
-            "Schema cookie: " + std::to_string(header.schemaCookie) + "\n" +
-            "Schema format number: " + std::to_string(header.schemaFormatNumber) + "\n" +
-            "Default page cache size bytes: " + std::to_string(header.defaultPageCacheSizeBytes) + "\n" +
-            "Largest B tree page number: " + std::to_string(header.largestBTreePageNumber) + "\n" +
-            "Database text encoding: " + std::to_string(header.databaseTextEncoding) + "\n" +
-            "User version: " + std::to_string(header.userVersion) + "\n" +
-            "Incremental vaccum mode: " + std::to_string(header.incrementalVaccumMode) + "\n" +
-            "Application ID: " + std::to_string(header.applicationId) + "\n" +
-            "Version valid for: " + std::to_string(header.versionValidFor) + "\n" +
-            "SQLite version: " + std::to_string(header.sqliteVersion) + "\n";
+            "Magic header string: "           + std::string(&header.headerStr[0], &header.headerStr[15]) + "\n" +
+            "Page size bytes: "               + std::to_string(header.pageSizeBytes)                     + "\n" +
+            "File format write version: "     + std::to_string(header.fileFormatWriteVersion)            + "\n" +
+            "File format read version: "      + std::to_string(header.fileFormatReadVersion)             + "\n" +
+            "Reserved space bytes: "          + std::to_string(header.reservedSpaceBytes)                + "\n" +
+            "Max embedded payload fraction "  + std::to_string(header.maxEmbeddedPayloadFrac)            + "\n" +
+            "Min embedded payload fraction: " + std::to_string(header.minEmbeddedPayloadFrac)            + "\n" +
+            "Leaf payload fraction: "         + std::to_string(header.leafPayloadFrac)                   + "\n" +
+            "File change counter: "           + std::to_string(header.fileChangeCounter)                 + "\n" +
+            "Database size pages: "           + std::to_string(header.databaseSizePages)                 + "\n" +
+            "First freelist trunk page: "     + std::to_string(header.firstFreelistTrunkPage)            + "\n" +
+            "Total freelist trunk pages: "    + std::to_string(header.totalFreelistPages)                + "\n" +
+            "Schema cookie: "                 + std::to_string(header.schemaCookie)                      + "\n" +
+            "Schema format number: "          + std::to_string(header.schemaFormatNumber)                + "\n" +
+            "Default page cache size bytes: " + std::to_string(header.defaultPageCacheSizeBytes)         + "\n" +
+            "Largest B tree page number: "    + std::to_string(header.largestBTreePageNumber)            + "\n" +
+            "Database text encoding: "        + std::to_string(header.databaseTextEncoding)              + "\n" +
+            "User version: "                  + std::to_string(header.userVersion)                       + "\n" +
+            "Incremental vaccum mode: "       + std::to_string(header.incrementalVaccumMode)             + "\n" +
+            "Application ID: "                + std::to_string(header.applicationId)                     + "\n" +
+            "Version valid for: "             + std::to_string(header.versionValidFor)                   + "\n" +
+            "SQLite version: "                + std::to_string(header.sqliteVersion)                     + "\n";
         return pub_data;
     }
 
@@ -246,9 +246,6 @@ namespace xeus_sqlite
                                         const std::string& code,
                                         xv::df_type& xv_sqlite_df)
     {
-        //TODO: all of the xvega outputs can be tested before we add stuff
-        //in them. Might improve performance?
-
         SQLite::Statement query(*m_db, code);
         nl::json pub_data;
 
@@ -287,7 +284,9 @@ namespace xeus_sqlite
             /* Builds text/html output */
             html_table << "</tr>\n";
 
-            /* Iterates through cols' rows and builds different kinds of outputs */
+            /* Iterates through cols' rows and builds different kinds of
+               outputs
+            */
             while (query.executeStep())
             {
                 /* Builds text/html output */
@@ -346,6 +345,9 @@ namespace xeus_sqlite
         std::vector<std::string> tokenized_input = tokenizer(sanitized_code);
 
         /* This structure is only used when xvega code is run */
+        //TODO: but it ends up being used in process_SQLite_input, that's why
+        //it's initialized here. Not the best approach, this should be
+        //compartimentilized under xvega domain.
         xv::df_type xv_sqlite_df;
 
         try
@@ -368,11 +370,10 @@ namespace xeus_sqlite
                     nl::json chart;
                     std::vector<std::string> xvega_input, sqlite_input;
 
-
                     std::tie(xvega_input, sqlite_input) = 
                         xv_sqlite::split_xv_sqlite_input(tokenized_input);
 
-                    /* Stringfies SQLite run code again */
+                    /* Stringfies SQLite code again */
                     std::stringstream stringfied_sqlite_input;
                     for (size_t i = 0; i < sqlite_input.size(); i++) {
                         stringfied_sqlite_input << " " << sqlite_input[i];
@@ -451,8 +452,8 @@ namespace xeus_sqlite
             _  _ ____ _  _ ____    ____ ____ _    _ ___ ____
              \/  |___ |  | [__  __ [__  |  | |    |  |  |___
             _/\_ |___ |__| ___]    ___] |_\| |___ |  |  |___
-          xeus-SQLite: a Jupyter kernel for SQLite
-          SQLite version: x.x.x
+           xeus-SQLite: a Jupyter kernel for SQLite
+           SQLite version: x.x.x
         */
 
         std::string banner = ""

--- a/src/xvega_bindings.cpp
+++ b/src/xvega_bindings.cpp
@@ -21,426 +21,388 @@ namespace nl = nlohmann;
 namespace xeus_sqlite
 {
 
-    xv_sqlite::xv_sqlite(xv::Chart& chart) : chart(chart)
+    //TODO: I don't think most final value() are necessary
+
+    template<typename T>
+    struct parser_base
     {
-    }
+        using input_it = std::vector<std::string>::iterator;
+        using point_it_fun = std::function<void(T*, const input_it&)>;
+        using range_it_fun = std::function<input_it(T*,
+                                                    const input_it&,
+                                                    const input_it&)>;
+        using parse_function_types = xtl::variant<point_it_fun,
+                                                  range_it_fun>;
 
-    xv_sqlite::~xv_sqlite()
-    {
-    }
+        struct command_info {
+            int number_required_arguments;
+            parse_function_types parse_function;
+        };
 
-    const std::map<std::string, xv_sqlite::command_info> xv_sqlite::xvega_mapping_table = {
-        {"WIDTH",   { 1, &xv_sqlite::parse_width   }},
-        {"HEIGHT",  { 1, &xv_sqlite::parse_height  }},
-        {"X_FIELD", { 1, &xv_sqlite::parse_x_field }},
-        {"Y_FIELD", { 1, &xv_sqlite::parse_y_field }},
-        {"MARK",    { 1, &xv_sqlite::parse_mark    }},
-    };
+        using free_fun = std::function<void()>;
 
-    const std::map<std::string, xv_sqlite::command_info> xv_sqlite::mark_mapping_table = {
-        {"COLOR", { 1, &xv_sqlite::parse_mark_color }}
-    };
+        std::map<std::string, command_info> mapping_table;
 
-    const std::map<std::string, xv_sqlite::command_info> xv_sqlite::x_field_mapping_table = {
-        {"TYPE",      { 1, &xv_sqlite::parse_x_field_type      }},
-        {"BIN",       { 1, &xv_sqlite::parse_x_field_bin       }},
-        {"AGGREGATE", { 1, &xv_sqlite::parse_x_field_aggregate }},
-        // {"TITLE",     { 1, &xv_sqlite::parse_x_field_title     }},
-        // {"GRID",      { 1, &xv_sqlite::parse_x_field_grid      }},
-    };
-
-    const std::map<std::string, xv_sqlite::command_info> xv_sqlite::y_field_mapping_table = {
-        {"TYPE", { 1, &xv_sqlite::parse_y_field_type }},
-        {"BIN",  { 1, &xv_sqlite::parse_y_field_bin  }},
-        {"AGGREGATE", { 1, &xv_sqlite::parse_y_field_aggregate }},
-    };
-
-    xv_sqlite::input_it xv_sqlite::parse_width(const xv_sqlite::input_it& input)
-    {
-        this->chart.width() = std::stoi(*input);
-        return input + 1;
-    }
-
-    xv_sqlite::input_it xv_sqlite::parse_height(const xv_sqlite::input_it& input)
-    {
-        this->chart.height() = std::stoi(*input);
-        return input + 1;
-    }
-
-    xv_sqlite::input_it xv_sqlite::parse_x_field(const xv_sqlite::input_it& input,
-                                                 const xv_sqlite::input_it& end)
-    {
-        xv::X x_enc = xv::X()
-                        .field(*(input))
-                        .type("quantitative");
-        this->chart.encoding().value().x = x_enc;
-
-        xv_sqlite::input_it it = input + 1;
-        bool succeeded;
-
-        do
+        /* Switch implementation with strings */
+        bool simple_switch(const std::string& token,
+                           std::map<std::string,
+                           free_fun> handlers)
         {
-            std::tie(it, succeeded) = xvega_execution_step(it, end, x_field_mapping_table);
-        } while (succeeded);
+            auto handler_it = handlers.find(to_upper(token));
+            if (handler_it == handlers.end()) {
+                return false;
+            }
+            /* Call the handler */
+            handler_it->second();
+            return true;
+        }
 
-        return it;
-    }
-
-    xv_sqlite::input_it xv_sqlite::parse_x_field_type(const xv_sqlite::input_it& input,
-                                                      const xv_sqlite::input_it& end)
-    {
-        const std::map<std::string, xv_sqlite::command_info> x_field_type_mapping_table = {
-            {"QUANTITATIVE", { 0, [this]{ this->chart.encoding().value().x().value().type().value() = "quantitative"; }}},
-            {"ORDINAL",      { 0, [this]{ this->chart.encoding().value().x().value().type().value() = "ordinal";      }}},
-            {"NOMINAL",      { 0, [this]{ this->chart.encoding().value().x().value().type().value() = "nominal";      }}},
-        };
-
-        xv_sqlite::input_it it = input;
-
-        std::tie(it, std::ignore) = xvega_execution_step(it, end, x_field_type_mapping_table);
-
-        return it;
-    }
-
-    xv_sqlite::input_it xv_sqlite::parse_x_field_bin(const xv_sqlite::input_it& input,
-                                                     const xv_sqlite::input_it& end)
-    {
-        const std::map<std::string, xv_sqlite::command_info> x_field_bin_mapping_table = {
-            {"TRUE",  { 0, [this]{ this->chart.encoding().value().x().value().bin().value() = true;  }}},
-            {"FALSE", { 0, [this]{ this->chart.encoding().value().x().value().bin().value() = false; }}},
-        };
-
-        xv_sqlite::input_it it = input + 1;
-        std::tie(it, std::ignore) = xvega_execution_step(it, end, x_field_bin_mapping_table);
-
-        return it;
-    }
-
-    xv_sqlite::input_it xv_sqlite::parse_x_field_aggregate(const xv_sqlite::input_it& input,
-                                                           const xv_sqlite::input_it& end)
-    {
-        const std::map<std::string, xv_sqlite::command_info> x_field_aggregate_mapping_table = {
-            {"COUNT",     { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "count";     }}},
-            {"VALID",     { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "valid";     }}},
-            {"MISSING",   { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "missing";   }}},
-            {"DISTINCT",  { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "distinct";  }}},
-            {"SUM",       { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "sum";       }}},
-            {"PRODUCT",   { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "product";   }}},
-            {"MEAN",      { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "mean";      }}},
-            {"AVERAGE",   { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "average";   }}},
-            {"VARIANCE",  { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "variance";  }}},
-            {"VARIANCEP", { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "variancep"; }}},
-            {"STDEV",     { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "stdev";     }}},
-            {"STEDEVP",   { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "stedevp";   }}},
-            {"STEDERR",   { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "stederr";   }}},
-            {"MEDIAN",    { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "median";    }}},
-            {"Q1",        { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "q1";        }}},
-            {"Q3",        { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "q3";        }}},
-            {"CI0",       { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "ci0";       }}},
-            {"CI1",       { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "ci1";       }}},
-            {"MIN",       { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "min";       }}},
-            {"MAX",       { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "max";       }}},
-            {"ARGMIN",    { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "argmin";    }}},
-            {"ARGMAX",    { 0, [this]{ this->chart.encoding().value().x().value().aggregate().value() = "argmax";    }}},
-            //TODO: missing values arg
-        };
-
-        xv_sqlite::input_it it = input + 1;
-        std::tie(it, std::ignore) = xvega_execution_step(it, end, x_field_aggregate_mapping_table);
-
-        return it;
-    }
-
-    // //TODO: I don't know why it doesn't work
-    // xv_sqlite::input_it xv_sqlite::parse_x_field_title(const xv_sqlite::input_it& input)
-    // {
-    //     xv_sqlite::input_it it = input;
-    //     std::vector<std::string> v = {*it};
-    //     auto x_axis = xtl::get<0>(this->chart.encoding().value().x().value().axis().value());
-    //     x_axis.title().value() = v;
-    //     this->chart.encoding().value().x().value().axis().value() = x_axis;
-    //     return it + 1;
-    // }
-
-    // //TODO: I don't know if this is working
-    // xv_sqlite::input_it xv_sqlite::parse_x_field_grid(const xv_sqlite::input_it& input,
-    //                                                   const xv_sqlite::input_it& end)
-    // {
-    //     const std::map<std::string, xv_sqlite::command_info> x_field_grid_mapping_table = {
-    //         // {"TRUE",  { 0, [this]{ xtl::get<0>(this->chart.encoding().value().x().value().axis().value()).grid().value() = true; std::cout << "🐉TRU🐉\n"; }}},
-    //         {"FALSE", { 0, [this]{ 
-    //             auto ac = xv::axis_config().grid(false);
-    //             auto cf = xv::Config().axis(ac);
-    //             this->chart.config() = cf;
-    //             std::cout << "sets grid to false\n";}}},
-    //     };
-
-    //     xv_sqlite::input_it it = input;
-    //     std::tie(it, std::ignore) = xvega_execution_step(it, end, x_field_grid_mapping_table);
-
-    //     return it;
-    // }
-
-    xv_sqlite::input_it xv_sqlite::parse_y_field(const xv_sqlite::input_it& input,
-                                                 const xv_sqlite::input_it& end)
-    {
-        xv::Y y_enc = xv::Y()
-                        .field(*(input))
-                        .type("quantitative");
-        this->chart.encoding().value().y = y_enc;
-
-        xv_sqlite::input_it it = input + 1;
-        bool succeeded;
-
-        do
+        /* Handle initial tokens before parse_loop takes over using the mapping
+           table
+        */
+        input_it parse_init(const input_it& begin, const input_it& end)
         {
-            std::tie(it, succeeded) = xvega_execution_step(it, end, y_field_mapping_table);
-        } while (succeeded);
+            return begin;
+        }
 
-        return it;
-    }
-
-    xv_sqlite::input_it xv_sqlite::parse_y_field_type(const xv_sqlite::input_it& input,
-                                                      const xv_sqlite::input_it& end)
-    {
-        const std::map<std::string, xv_sqlite::command_info> y_field_type_mapping_table = {
-            {"QUANTITATIVE", { 0, [this]{ this->chart.encoding().value().y().value().type().value() = "quantitative"; }}},
-            {"ORDINAL",      { 0, [this]{ this->chart.encoding().value().y().value().type().value() = "ordinal";      }}},
-            {"NOMINAL",      { 0, [this]{ this->chart.encoding().value().y().value().type().value() = "nominal";      }}},
-        };
-
-        xv_sqlite::input_it it = input;
-
-        std::tie(it, std::ignore) = xvega_execution_step(it, end, y_field_type_mapping_table);
-        return it;
-    }
-
-    xv_sqlite::input_it xv_sqlite::parse_y_field_bin(const xv_sqlite::input_it& input,
-                                                     const xv_sqlite::input_it& end)
-    {
-        const std::map<std::string, xv_sqlite::command_info> y_field_bin_mapping_table = {
-            {"TRUE",  { 0, [this]{ this->chart.encoding().value().y().value().bin().value() = true;  }}},
-            {"FALSE", { 0, [this]{ this->chart.encoding().value().y().value().bin().value() = false; }}}
-        };
-
-        xv_sqlite::input_it it = input + 1;
-        std::tie(it, std::ignore) = xvega_execution_step(it, end, y_field_bin_mapping_table);
-
-        return it;
-    }
-
-    xv_sqlite::input_it xv_sqlite::parse_y_field_aggregate(const xv_sqlite::input_it& input,
-                                                           const xv_sqlite::input_it& end)
-    {
-        const std::map<std::string, xv_sqlite::command_info> y_field_aggregate_mapping_table = {
-            {"COUNT",     { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "count";     }}},
-            {"VALID",     { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "valid";     }}},
-            {"MISSING",   { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "missing";   }}},
-            {"DISTINCT",  { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "distinct";  }}},
-            {"SUM",       { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "sum";       }}},
-            {"PRODUCT",   { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "product";   }}},
-            {"MEAN",      { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "mean";      }}},
-            {"AVERAGE",   { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "average";   }}},
-            {"VARIANCE",  { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "variance";  }}},
-            {"VARIANCEP", { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "variancep"; }}},
-            {"STDEV",     { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "stdev";     }}},
-            {"STEDEVP",   { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "stedevp";   }}},
-            {"STEDERR",   { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "stederr";   }}},
-            {"MEDIAN",    { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "median";    }}},
-            {"Q1",        { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "q1";        }}},
-            {"Q3",        { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "q3";        }}},
-            {"CI0",       { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "ci0";       }}},
-            {"CI1",       { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "ci1";       }}},
-            {"MIN",       { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "min";       }}},
-            {"MAX",       { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "max";       }}},
-            {"ARGMIN",    { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "argmin";    }}},
-            {"ARGMAX",    { 0, [this]{ this->chart.encoding().value().y().value().aggregate().value() = "argmax";    }}},
-            //TODO: missing values arg
-        };
-
-        xv_sqlite::input_it it = input + 1;
-        std::tie(it, std::ignore) = xvega_execution_step(it, end, y_field_aggregate_mapping_table);
-
-        return it;
-    }
-
-
-    xv_sqlite::input_it xv_sqlite::parse_mark(const xv_sqlite::input_it& input,
-                                              const xv_sqlite::input_it& end)
-    {
-        //TODO: should only accept one attribute for marks
-        const std::map<std::string, xv_sqlite::command_info> mark_attr_mapping_table = {
-            {"ARC",    { 0, [this]{ this->chart.mark() = xv::mark_arc();    }}},
-            {"AREA",   { 0, [this]{ this->chart.mark() = xv::mark_area();   }}},
-            {"BAR",    { 0, [this]{ this->chart.mark() = xv::mark_bar();    }}},
-            {"CIRCLE", { 0, [this]{ this->chart.mark() = xv::mark_circle(); }}},
-            {"LINE",   { 0, [this]{ this->chart.mark() = xv::mark_line();   }}},
-            {"POINT",  { 0, [this]{ this->chart.mark() = xv::mark_point();  }}},
-            {"RECT",   { 0, [this]{ this->chart.mark() = xv::mark_rect();   }}},
-            {"RULE",   { 0, [this]{ this->chart.mark() = xv::mark_rule();   }}},
-            {"SQUARE", { 0, [this]{ this->chart.mark() = xv::mark_square(); }}},
-            {"TICK",   { 0, [this]{ this->chart.mark() = xv::mark_tick();   }}},
-            {"TRAIL",  { 0, [this]{ this->chart.mark() = xv::mark_trail();  }}},
-        };
-
-        xv_sqlite::input_it it = input;
-        bool succeeded;
-
-        std::tie(it, std::ignore) = xvega_execution_step(input, end, mark_attr_mapping_table);
-
-        do
+        /* Parse a single token (and its dependencies)
+           Returns an iterator past the last successfully parsed token
+        */
+        input_it parse_step(const input_it& begin, const input_it& end)
         {
-            std::tie(it, succeeded) = xvega_execution_step(it, end, mark_mapping_table);
-        } while (succeeded);
+            input_it it = begin;
 
-        return it;
-    }
-
-    xv_sqlite::input_it xv_sqlite::parse_mark_color(const xv_sqlite::input_it& input)
-    {
-        struct visitor
-        {
-            std::string m_color;
-
-            visitor(const std::string& color): m_color(color)
+            auto cmd_it = mapping_table.find(to_upper(*it));
+            if (cmd_it == mapping_table.end())
             {
+                return it; 
             }
 
-            void operator()(xv::mark_arc& m)      { m.color = m_color; }
-            void operator()(xv::mark_area& m)     { m.color = m_color; }
-            void operator()(xv::mark_bar& m)      { m.color = m_color; }
-            void operator()(xv::mark_circle& m)   { m.color = m_color; }
-            void operator()(xv::mark_line& m)     { m.color = m_color; }
-            void operator()(xv::mark_point& m)    { m.color = m_color; }
-            void operator()(xv::mark_rect& m)     { m.color = m_color; }
-            void operator()(xv::mark_rule& m)     { m.color = m_color; }
-            void operator()(xv::mark_square& m)   { m.color = m_color; }
-            void operator()(xv::mark_tick& m)     { m.color = m_color; }
-            void operator()(xv::mark_trail& m)    { m.color = m_color; }
-            void operator()(xv::mark_geoshape& m) { m.color = m_color; }
-            void operator()(xv::mark_image& m)    { m.color = m_color; }
-            void operator()(xv::mark_text& m)     { m.color = m_color; }
-        };
+            command_info cmd_info = cmd_it->second;
 
-        //TODO: validate input: color must be lowercase
-        visitor v(*input);
-        xtl::visit(v, this->chart.mark());
-        return input + 1;
-    }
+            /* Prevents code to end prematurely */
+            if (std::distance(it, end) < cmd_info.number_required_arguments)
+            {
+                throw std::runtime_error("Arguments missing.");
+            }
 
-    std::pair<xv_sqlite::input_it, bool> xv_sqlite::xvega_execution_step(
-                                         const xv_sqlite::input_it& begin,
-                                         const xv_sqlite::input_it& end,
-                                         const std::map<std::string,
-                                         xv_sqlite::command_info> mapping_table)
+            /* Advances to next token */
+            ++it;
+
+            /* Calls parsing function for command */
+            if (cmd_info.parse_function.index() == 0)
+            {
+                /* Calls command functions that receive a point iterator */
+                xtl::get<0>(cmd_info.parse_function)(static_cast<T*>(this), it);
+                it++;
+            }
+            else if (cmd_info.parse_function.index() == 1)
+            {
+                /* Calls command functions that receive a range iterator */
+                it = xtl::get<1>(cmd_info.parse_function)(static_cast<T*>(this),
+                                                          it,
+                                                          end);
+            }
+
+            return it;
+        }
+
+        /* Parse all tokens in the range of iterators passed
+           Returns an iterator past the last successfully parsed token
+        */
+        input_it parse_loop(const input_it& begin, const input_it& end)
+        {
+            /* First handle initial tokens */
+            input_it it = static_cast<T*>(this)->parse_init(begin, end);
+
+            /* Then move on to the mapping table */
+            while (it != end)
+            {
+                input_it next = parse_step(it, end);
+
+                if (next == it)
+                {
+                    break;
+                }
+
+                it = next;
+            }
+
+            return it;
+        }
+    };
+
+    struct field_parser : parser_base<field_parser>
     {
-        xv_sqlite::input_it it = begin;
+        using xy_variant = xtl::variant<xv::X*, xv::Y*>;
+        xy_variant enc;
 
-        auto cmd_it = mapping_table.find(to_upper(*it));
-
-
-        if (cmd_it == mapping_table.end())
+        field_parser(xy_variant enc) : enc(enc)
         {
-            return std::make_pair(it, false); 
+            mapping_table = {
+                {"TYPE",      { 1, &field_parser::parse_field_type      }},
+                {"BIN",       { 1, &field_parser::parse_field_bin       }},
+                {"AGGREGATE", { 1, &field_parser::parse_field_aggregate }},
+                {"TIME_UNIT", { 1, &field_parser::parse_field_time_unit }},
+            };
         }
 
-        xv_sqlite::command_info cmd_info = cmd_it->second;
-
-        /* Prevents code to end prematurely.*/
-        if (std::distance(it, end) < cmd_info.number_required_arguments)
+        input_it parse_init(const input_it& begin, const input_it&)
         {
-            throw std::runtime_error(std::string("Arguments missing."));
+            xtl::visit([&](auto &&x_or_y)
+            {
+                x_or_y->field = *begin;
+                x_or_y->type = "quantitative";
+            }, enc);
+
+            return begin + 1;
         }
 
-        /* Advances to next parameter if command has parameters */
-        if (cmd_info.number_required_arguments > 0)
+        void parse_field_bin(const input_it& it)
         {
-            ++it;
-        }
-        /* Calls parsing function for command */
-        if (cmd_info.parse_function.index() == 0)
-        {
-            /* Calls command functions that receive a point iterator*/
-            it = xtl::get<0>(cmd_info.parse_function)(*this, it);
-        }
-        else if (cmd_info.parse_function.index() == 1)
-        {
-            /* Calls command functions that receive a range iterator */
-            it = xtl::get<1>(cmd_info.parse_function)(*this, it, end);
-        }
-        else if (cmd_info.parse_function.index() == 2)
-        {
-            /* Treat case where functions return void */
-            xtl::get<2>(cmd_info.parse_function)();
-            ++it;
+            bool found = xtl::visit([&](auto &&x_or_y)
+            {
+                return simple_switch(*it,
+                {
+                    {"TRUE",  [&]{ x_or_y->bin().value() = true; }},
+                    {"FALSE", [&]{ x_or_y->bin().value() = false; }},
+                });
+            }, enc);
+            if (!found)
+            {
+                throw std::runtime_error("Missing or invalid BIN type");
+            }
         }
 
-        return std::make_pair(it, true);
+        void parse_field_type(const input_it& it)
+        {
+            bool found = xtl::visit([&](auto &&x_or_y)
+            {
+                return simple_switch(*it,
+                {
+                    {"QUANTITATIVE", [&]{ x_or_y->type().value() = "quantitative"; }},
+                    {"NOMINAL",      [&]{ x_or_y->type().value() = "nominal";      }},
+                    {"ORDINAL",      [&]{ x_or_y->type().value() = "ordinal";      }},
+                    {"TEMPORAL",     [&]{ x_or_y->type().value() = "temporal";     }},
+                });
+            }, enc);
+            if (!found)
+            {
+                throw std::runtime_error("Missing or invalid TYPE type");
+            }
+        }
 
-        //TODO: use a visitor instead of index
-        //The impl. is too complex, don't think it's worth it, but should we?
-        // struct visitor
-        // {
-        //     xv_sqlite* _this;
-        //     const xv_sqlite::input_it& it;
-        //     const xv_sqlite::input_it& end;
+        input_it parse_field_aggregate(const input_it& begin, const input_it&)
+        {
+            bool found = xtl::visit([&](auto &&x_or_y)
+            {
+                return simple_switch(*begin,
+                {
+                    {"COUNT",     [&]{ x_or_y->aggregate().value() = "count";     }},
+                    {"VALID",     [&]{ x_or_y->aggregate().value() = "valid";     }},
+                    {"MISSING",   [&]{ x_or_y->aggregate().value() = "missing";   }},
+                    {"DISTINCT",  [&]{ x_or_y->aggregate().value() = "distinct";  }},
+                    {"SUM",       [&]{ x_or_y->aggregate().value() = "sum";       }},
+                    {"PRODUCT",   [&]{ x_or_y->aggregate().value() = "product";   }},
+                    {"MEAN",      [&]{ x_or_y->aggregate().value() = "mean";      }},
+                    {"AVERAGE",   [&]{ x_or_y->aggregate().value() = "average";   }},
+                    {"VARIANCE",  [&]{ x_or_y->aggregate().value() = "variance";  }},
+                    {"VARIANCEP", [&]{ x_or_y->aggregate().value() = "variancep"; }},
+                    {"STDEV",     [&]{ x_or_y->aggregate().value() = "stdev";     }},
+                    {"STEDEVP",   [&]{ x_or_y->aggregate().value() = "stedevp";   }},
+                    {"STEDERR",   [&]{ x_or_y->aggregate().value() = "stederr";   }},
+                    {"MEDIAN",    [&]{ x_or_y->aggregate().value() = "median";    }},
+                    {"Q1",        [&]{ x_or_y->aggregate().value() = "q1";        }},
+                    {"Q3",        [&]{ x_or_y->aggregate().value() = "q3";        }},
+                    {"CI0",       [&]{ x_or_y->aggregate().value() = "ci0";       }},
+                    {"CI1",       [&]{ x_or_y->aggregate().value() = "ci1";       }},
+                    {"MIN",       [&]{ x_or_y->aggregate().value() = "min";       }},
+                    {"MAX",       [&]{ x_or_y->aggregate().value() = "max";       }},
+                    {"ARGMIN",    [&]{ x_or_y->aggregate().value() = "argmin";    }},
+                    {"ARGMAX",    [&]{ x_or_y->aggregate().value() = "argmax";    }},
+                    //TODO: missing values arg
+                });
+            }, enc);
+            if (!found)
+            {
+                throw std::runtime_error("Missing or invalid AGGREGATE type");
+            }
+            return begin + 1;
+        }
 
-        //     visitor(xv_sqlite* _this,
-        //             const xv_sqlite::input_it& it,
-        //             const xv_sqlite::input_it& end)
-        //                 : _this(_this)
-        //                 , it(it)
-        //                 , end(end)
-        //     {
-        //     }
+        //TODO: must set title again, it disappears once you set the time unit
+        // this problem might be related with the setting TITLE of the graph
+        void parse_field_time_unit(const input_it& it)
+        {
+            bool found = xtl::visit([&](auto &&x_or_y)
+            {
+                return simple_switch(*it,
+                {
+                    {"YEAR",        [&]{ x_or_y->timeUnit().value() = "year";        }},
+                    {"QUARTER",     [&]{ x_or_y->timeUnit().value() = "quarter";     }},
+                    {"MONTH",       [&]{ x_or_y->timeUnit().value() = "month";       }},
+                    {"DAY",         [&]{ x_or_y->timeUnit().value() = "day";         }},
+                    {"DATE",        [&]{ x_or_y->timeUnit().value() = "date";        }},
+                    {"HOURS",       [&]{ x_or_y->timeUnit().value() = "hours";       }},
+                    {"MINUTES",     [&]{ x_or_y->timeUnit().value() = "minutes";     }},
+                    {"SECONDS",     [&]{ x_or_y->timeUnit().value() = "seconds";     }},
+                    {"MILISECONDS", [&]{ x_or_y->timeUnit().value() = "miliseconds"; }},
+                });
+            }, enc);
+            if (!found)
+            {
+                throw std::runtime_error("Missing or invalid TIME_UNIT type");
+            }
+        }
+    };
 
-        //     /* Types must be variant of all possible outcomes because the visit function can't choose right type byt itself */
-        //     xtl::variant<std::monostate, xv_sqlite::input_it> operator()(xv_sqlite::point_it_fun f) { return f(*_this, it); }
-        //     xtl::variant<std::monostate, xv_sqlite::input_it> operator()(xv_sqlite::range_it_fun f) { return f(*_this, it, end); }
-        //     xtl::variant<std::monostate, xv_sqlite::input_it> operator()(xv_sqlite::free_fun f) { f(); }
-        // };
+    struct mark_parser : parser_base<mark_parser>
+    {
+        xv::Chart& chart;
 
-        // visitor v(this, it, end);
+        mark_parser(xv::Chart& chart) : chart(chart)
+        {
+            mapping_table =
+            {
+                {"COLOR", { 1, &mark_parser::parse_color }},
+            };
+        }
 
-        // xtl::variant<std::monostate, xv_sqlite::input_it> ret = xtl::visit(v, cmd_info.parse_function);
+        input_it parse_init(const input_it& begin, const input_it&)
+        {
+            bool found = simple_switch(*begin,
+            {
+                {"ARC",    [&]{ this->chart.mark() = xv::mark_arc();    }},
+                {"AREA",   [&]{ this->chart.mark() = xv::mark_area();   }},
+                {"BAR",    [&]{ this->chart.mark() = xv::mark_bar();    }},
+                {"CIRCLE", [&]{ this->chart.mark() = xv::mark_circle(); }},
+                {"LINE",   [&]{ this->chart.mark() = xv::mark_line();   }},
+                {"POINT",  [&]{ this->chart.mark() = xv::mark_point();  }},
+                {"RECT",   [&]{ this->chart.mark() = xv::mark_rect();   }},
+                {"RULE",   [&]{ this->chart.mark() = xv::mark_rule();   }},
+                {"SQUARE", [&]{ this->chart.mark() = xv::mark_square(); }},
+                {"TICK",   [&]{ this->chart.mark() = xv::mark_tick();   }},
+                {"TRAIL",  [&]{ this->chart.mark() = xv::mark_trail();  }},
+            });
+            if (!found)
+            {
+                throw std::runtime_error("Missing or invalid MARK type");
+            }
+            return begin + 1;
+        }
 
-        // if (ret.index() == 1)
-        // {
-        //     it = xtl::get<1>(ret);
-        // }
-    }
+        void parse_color(const input_it& it)
+        {
+            xtl::visit([&](auto&& mark_generic)
+            {
+                mark_generic.color = to_lower(*it);
+            }, this->chart.mark());
+        }
+    };
 
+    struct xv_sqlite_parser : parser_base<xv_sqlite_parser>
+    {
+        xv::Chart& chart;
 
+        xv_sqlite_parser(xv::Chart& chart) : chart(chart)
+        {
+            mapping_table = {
+                {"WIDTH",   { 1, &xv_sqlite_parser::parse_width   }},
+                {"HEIGHT",  { 1, &xv_sqlite_parser::parse_height  }},
+                {"X_FIELD", { 1, &xv_sqlite_parser::parse_x_field }},
+                {"Y_FIELD", { 1, &xv_sqlite_parser::parse_y_field }},
+                {"MARK",    { 1, &xv_sqlite_parser::parse_mark    }},
+                {"GRID",    { 1, &xv_sqlite_parser::parse_grid    }},
+                {"TITLE",   { 1, &xv_sqlite_parser::parse_title   }},
+            };
+        }
+
+        input_it parse_init(const input_it& begin, const input_it&)
+        {
+            auto ac = xv::axis_config().grid(true);
+            auto cf = xv::Config().axis(ac);
+            this->chart.config() = cf;
+            return begin;
+        }
+
+        void parse_width(const input_it& it)
+        {
+            this->chart.width() = std::stoi(*it);
+        }
+
+        void parse_height(const input_it& it)
+        {
+            this->chart.height() = std::stoi(*it);
+        }
+
+        input_it parse_x_field(const input_it& begin, const input_it& end)
+        {
+            std::vector<std::string> v;
+            auto ax = xv::Axis().title(v);
+            xv::X x_enc = xv::X().axis(ax);
+            this->chart.encoding().value().x = x_enc;
+
+            field_parser parser(&chart.encoding().value().x().value());
+            return parser.parse_loop(begin, end);
+        }
+
+        input_it parse_y_field(const input_it& begin, const input_it& end)
+        {
+            xv::Y y_enc = xv::Y();
+            this->chart.encoding().value().y = y_enc;
+
+            field_parser parser(&chart.encoding().value().y().value());
+            return parser.parse_loop(begin, end);
+        }
+
+        input_it parse_mark(const input_it& input, const input_it& end)
+        {
+            mark_parser parser(chart);
+            return parser.parse_loop(input, end);
+        }
+
+        void parse_grid(const input_it& it)
+        {
+
+            bool found = simple_switch(*it,
+                {
+                    {"TRUE",  [&]{ this->chart.config().value().axis().value().grid() = true;  }},
+                    {"FALSE", [&]{ this->chart.config().value().axis().value().grid() = false; }},
+                });
+            if (!found)
+            {
+                throw std::runtime_error("Missing or invalid GRID type");
+            }
+        }
+
+        //TODO: not working
+        void parse_title(const input_it& it)
+        {
+            std::vector<std::string> v = {*it};
+            this->chart.config().value().axis().value().title() = v;
+        }
+    };
 
     nl::json xv_sqlite::process_xvega_input(std::vector<std::string>
                                                tokenized_input,
                                                xv::df_type xv_sqlite_df)
     {
-        /* Initializes and populates xeus_sqlite object*/
+        /* Initializes and populates xeus_sqlite object */
         xv::Chart chart;
         chart.encoding() = xv::Encodings();
-        xv_sqlite context(chart);
 
         /* Populates chart with data gathered on interpreter::process_SQLite_input */
         xv::data_frame data_frame;
         data_frame.values = xv_sqlite_df;
         chart.data() = data_frame;
-        input_it it = tokenized_input.begin();
 
-        bool succeeded;
-
-        /* Main execution loop */
-        while (it != tokenized_input.end())
+        /* Parse XVEGA_PLOT syntax */
+        xv_sqlite_parser parser(chart);
+        auto last_parsed = parser.parse_loop(tokenized_input.begin(),
+                                             tokenized_input.end());
+        if (last_parsed != tokenized_input.end())
         {
-            std::tie(it, succeeded) = 
-                context.xvega_execution_step(it,
-                                             tokenized_input.end(),
-                                             xvega_mapping_table);
-
-            if (!succeeded)
-            {
-                throw std::runtime_error("This is not a valid command for SQLite XVega.");
-            }
+            throw std::runtime_error("This is not a valid command for SQLite XVega.");
         }
 
         nl::json bundle;


### PR DESCRIPTION
The point of this PR is to remove code duplication caused by the need of creating different objects to deal with different axis (X and Y). The xvega API doesn't offer a parent class common to these two attributes which caused us to have to dup. code for X and Y.
Here we're adding a template solution, which allow us to call the children on the parent eg: `    struct field_parser : parser_base<field_parser>`, the reason why we're doing this instead of writing a typical heritage system is that we'd have to declare all methods used in all children classes in the base class, causing a bunch of useless code to be written.
This PR also removes and simplifies a bunch of logic around `visit`, using things like:
```
            bool found = xtl::visit([&](auto &&x_or_y)
            {
                return simple_switch(*it,
                {
                    {"TRUE",  [&]{ x_or_y->bin().value() = true; }},
                    {"FALSE", [&]{ x_or_y->bin().value() = false; }},
                });
            }, enc);
```
Where throughout some cpp magic visit figures out the type you're calling with `&&x_or_y`.