### PR TITLE
Typo wrong link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 `xeus-sqlite` is a Jupyter kernel for SQL based on the native implementation of the Jupyter protocol [xeus](https://github.com/jupyter-xeus/xeus).
 
-`xeus-sqlite` now supports [vega](vega.github.io/) visualizations thanks to [xvega](https://github.com/Quantstack/xvega).
+`xeus-sqlite` now supports [vega](https://vega.github.io/) visualizations thanks to [xvega](https://github.com/Quantstack/xvega).
 
 ## Usage
 


### PR DESCRIPTION
vega.github.io/ => https://vega.github.io/
The link was pointing to a non-existing file on GitHub.