### PR TITLE
chore: Add OS availability in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Launch the Jupyter notebook with `jupyter notebook` or Jupyter lab with `jupyter
 
 ## Installation
 
+xeus-sqlite has been packaged for the mamba (or conda) package manager on the **Linux** and **OS X** platforms. At the moment, we are not providing packages for the **Windows** platform.
+
 xeus-sqlite has been packaged for the mamba (or conda) package manager.
 
 To ensure that the installation works, it is preferable to install xeus-sqlite in a fresh environment.


### PR DESCRIPTION
xeus-cling has been packaged for the mamba (or conda) package manager on the **Linux** and **OS X** platforms. At the moment, we are not providing packages for the **Windows** platform.

inspired from: 

https://github.com/jupyter-xeus/xeus-cling/blob/471b1b68e3cad35746652cf14ce40ce0b7797ba0/README.md#L13

reference: 

no noarch or win-64 files here https://anaconda.org/conda-forge/xeus-sqlite/files