### PR TITLE
Update display name for xsqlite kernel

### DIFF
--- a/share/jupyter/kernels/xsqlite/kernel.json.in
+++ b/share/jupyter/kernels/xsqlite/kernel.json.in
@@ -1,5 +1,5 @@
 {
-    "display_name": "xsqlite",
+    "display_name": "SQLite (xsqlite)",
     "argv": [
         "@CMAKE_INSTALL_FULL_BINDIR@/xsqlite",
         "-f",


### PR DESCRIPTION
To align the display name with the other xeus kernels:

<img width="772" height="308" alt="image" src="https://github.com/user-attachments/assets/5daeaa66-e09a-45bb-a559-f9f41c812de2" />
